### PR TITLE
Fix XSS in genome note title rendering

### DIFF
--- a/src/app/data-portal/data-portal-details/data-portal-details.component.html
+++ b/src/app/data-portal/data-portal-details/data-portal-details.component.html
@@ -521,7 +521,7 @@
                                 </mat-expansion-panel-header>
                                 @for(gen of organismData?.genome_notes; track $index){
                                     <div class="genome-card">
-                                        <h3 class="title" [innerHTML]="sanitizeHTML(gen.title)"></h3>
+                                        <h3 class="title">{{ gen.title }}</h3>
                                         <div class="content">
                                             <img class="image" src="{{gen.figureURI}}" alt="Genome Image" (click)="openPopup(gen.figureURI)">
                                             <div class="text">

--- a/src/app/data-portal/data-portal-details/data-portal-details.component.ts
+++ b/src/app/data-portal/data-portal-details/data-portal-details.component.ts
@@ -15,7 +15,7 @@ import { MatAnchor } from '@angular/material/button';
 import {MatChip, MatChipSet} from '@angular/material/chips';
 import { MatExpansionPanel, MatExpansionPanelHeader } from '@angular/material/expansion';
 import {MapClusterComponent} from "../../map-cluster/map-cluster.component";
-import {DomSanitizer, SafeHtml, SafeResourceUrl} from "@angular/platform-browser";
+import {DomSanitizer, SafeResourceUrl} from "@angular/platform-browser";
 import {MatIcon} from "@angular/material/icon";
 import {MatDivider} from "@angular/material/divider";
 import {MatLine} from "@angular/material/core";
@@ -441,10 +441,6 @@ export class DataPortalDetailsComponent implements OnInit, AfterViewInit {
 
     hideLoader(){
         this.isLoading = false;
-    }
-
-    sanitizeHTML(content: string): SafeHtml {
-        return this.sanitizer.bypassSecurityTrustHtml(content);
     }
 
     openPopup(imageUrl: string) {


### PR DESCRIPTION
Render genome note titles as text-interpolated content instead of passing them through DomSanitizer.bypassSecurityTrustHtml, which disabled Angular's contextual output encoding and allowed arbitrary HTML/script from the API-supplied title to execute in the DOM.

Removed the now-unused sanitizeHTML() helper and SafeHtml import.